### PR TITLE
Persistence overhaul

### DIFF
--- a/src/Authenticator/CookieAuthenticator.php
+++ b/src/Authenticator/CookieAuthenticator.php
@@ -79,14 +79,6 @@ class CookieAuthenticator extends AbstractAuthenticator implements PersistenceIn
     }
 
     /**
-     * @inheritDoc
-     */
-    public function getStorage(): StorageInterface
-    {
-        return $this->storage;
-    }
-
-    /**
      * {@inheritDoc}
      */
     public function authenticate(ServerRequestInterface $request)

--- a/src/Authenticator/PersistenceInterface.php
+++ b/src/Authenticator/PersistenceInterface.php
@@ -14,20 +14,11 @@
  */
 namespace Authentication\Authenticator;
 
-use Authentication\Authenticator\Storage\StorageInterface;
-
 /**
  * Persistence Interface
  */
 interface PersistenceInterface
 {
-
-    /**
-     * Returns a persistence object
-     *
-     * @return \Authentication\Authenticator\Storage\StorageInterface;
-     */
-    public function getStorage(): StorageInterface;
 
     /**
      * Persists the users data

--- a/src/Authenticator/SessionAuthenticator.php
+++ b/src/Authenticator/SessionAuthenticator.php
@@ -93,14 +93,6 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
     }
 
     /**
-     * @inheritDoc
-     */
-    public function getStorage(): StorageInterface
-    {
-        return $this->storage;
-    }
-
-    /**
      * {@inheritDoc}
      */
     public function clearIdentity(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface

--- a/src/Authenticator/SessionAuthenticator.php
+++ b/src/Authenticator/SessionAuthenticator.php
@@ -15,10 +15,8 @@ namespace Authentication\Authenticator;
 
 use ArrayAccess;
 use ArrayObject;
-use Authentication\Authenticator\Persistence\PersistenceInterface as Persistence;
-use Authentication\Authenticator\Persistence\SessionPersistenceInterface;
+use Authentication\Authenticator\Storage\StorageInterface;
 use Authentication\Identifier\IdentifierInterface;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
@@ -30,7 +28,6 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
     /**
      * Default config for this object.
      * - `fields` The fields to use to verify a user by.
-     * - `sessionKey` Session key.
      * - `identify` Whether or not to identify user data stored in a session.
      *
      * @var array
@@ -39,30 +36,26 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
         'fields' => [
             IdentifierInterface::CREDENTIAL_USERNAME => 'username'
         ],
-        'sessionKey' => 'Auth',
         'identify' => false,
         'identityAttribute' => 'identity',
     ];
+
+    /**
+     * @var \Authentication\Authenticator\Storage\StorageInterface
+     */
+    protected $storage;
 
     /**
      * {@inheritDoc}
      */
     public function __construct(
         IdentifierCollection $identifiers,
-        SessionPersistenceInterface $persistence,
+        StorageInterface $storage,
         array $config = []
     ) {
         parent::__construct($identifiers, $config);
 
-        $this->persistence = $persistence;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function persistence(): Persistence
-    {
-        return $this->persistence;
+        $this->storage = $storage;
     }
 
     /**
@@ -70,13 +63,11 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The request to authenticate with.
      * @param \Psr\Http\Message\ResponseInterface $response The response to add headers to.
-     * @return \Authentication\Authenticator\ResultInterface
+     * @return ResultInterface
      */
     public function authenticate(ServerRequestInterface $request)
     {
-        $sessionKey = $this->config['sessionKey'];
-        $session = $request->getAttribute('session');
-        $user = $session->read($sessionKey);
+        $user = $this->storage->read($request);
 
         if (empty($user)) {
             return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND);
@@ -102,36 +93,26 @@ class SessionAuthenticator extends AbstractAuthenticator implements PersistenceI
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
-    public function persistIdentity($identity)
+    public function getStorage(): StorageInterface
     {
-        $this->persistence->persistIdentity($identity);
-        /*
-        $sessionKey = $this->config['sessionKey'];
-        $request->getAttribute('session')->write($sessionKey, $identity);
-
-        return [
-            'request' => $request,
-            'response' => $response,
-        ];
-        */
+        return $this->storage;
     }
 
     /**
      * {@inheritDoc}
      */
-    public function clearIdentity()
+    public function clearIdentity(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
     {
-        $this->persistence->clearIdentity();
-        /*
-        $sessionKey = $this->config['sessionKey'];
-        $request->getAttribute('session')->delete($sessionKey);
+        return $this->storage->clear($request, $response);
+    }
 
-        return [
-            'request' => $request->withoutAttribute($this->config['identityAttribute']),
-            'response' => $response
-        ];
-        */
+    /**
+     * {@inheritDoc}
+     */
+    public function persistIdentity(ServerRequestInterface $request, ResponseInterface $response, $identity): ResponseInterface
+    {
+        return $this->storage->write($request, $response, $identity);
     }
 }

--- a/src/Authenticator/Storage/CakeCookieStorage.php
+++ b/src/Authenticator/Storage/CakeCookieStorage.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         1.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Auth\Authenticator\Storage;
+
+use Authentication\Authenticator\Storage\StorageInterface;
+use Cake\Http\Cookie\Cookie;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Storage adapter for the CakePHP Cookie
+ */
+class CakeCookieStorage implements StorageInterface
+{
+    /**
+     * Default Config
+     *
+     * @var array
+     */
+    protected $defaultConfig = [
+        'cookie' => [
+            'name' => 'CookieAuth',
+            'expire' => null,
+            'path' => '/',
+            'domain' => '',
+            'secure' => false,
+            'httpOnly' => false
+        ]
+    ];
+
+    /**
+     * Config
+     *
+     * @var array
+     */
+    protected $config = [];
+
+    public function __construct(array $config = [])
+    {
+        $this->config = array_merge_recursive($this->defaultConfig, $config);
+    }
+
+    /**
+     * Creates a cookie instance with configured defaults.
+     *
+     * @param mixed $value Cookie value.
+     * @return \Cake\Http\Cookie\CookieInterface
+     */
+    protected function _createCookie($value)
+    {
+        $data = $this->config['cookie'];
+
+        $cookie = new Cookie(
+            $data['name'],
+            $value,
+            $data['expire'],
+            $data['path'],
+            $data['domain'],
+            $data['secure'],
+            $data['httpOnly']
+        );
+
+        return $cookie;
+    }
+
+    public function read(ServerRequestInterface $request)
+    {
+        $cookies = $request->getCookieParams();
+        $cookieName = $this->config['cookie']['name'];
+
+        if (!isset($cookies[$cookieName])) {
+            return null;
+        }
+
+        $value = $cookies[$cookieName];
+
+        if (is_string($value)) {
+            $value = json_decode($value, true);
+        }
+
+        return $value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function clear(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $cookie = $this->_createCookie(null)->withExpired();
+
+        return $response->withAddedHeader('Set-Cookie', $cookie->toHeaderValue());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function write(ServerRequestInterface $request, ResponseInterface $response, $data): ResponseInterface
+    {
+        if (!is_string($data)) {
+            $data = json_encode($data);
+        }
+
+        $cookie = $this->_createCookie($data);
+
+        return $response->withAddedHeader('Set-Cookie', $cookie->toHeaderValue());
+    }
+}

--- a/src/Authenticator/Storage/CakeSessionStorage.php
+++ b/src/Authenticator/Storage/CakeSessionStorage.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         1.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Authentication\Authenticator\Storage;
+
+use Cake\Http\Session;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Storage adapter for the CakePHP Session
+ */
+class CakeSessionStorage implements StorageInterface
+{
+    /**
+     * Default Config
+     *
+     * @var array
+     */
+    protected $defaultConfig = [
+        'sessionKey' => 'Auth',
+        'sessionAttribute' => 'session',
+    ];
+
+    /**
+     * Config
+     *
+     * @var array
+     */
+    protected $config = [];
+
+    public function __construct(array $config = [])
+    {
+        $this->config = $config + $this->defaultConfig;
+    }
+
+    public function clear(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $this->getSession($request)->delete($this->config['sessionKey']);
+
+        return $response;
+    }
+
+    public function read(ServerRequestInterface $request)
+    {
+        return $this->getSession($request)->read($this->config['sessionKey']);
+    }
+
+    public function write(ServerRequestInterface $request, ResponseInterface $response, $data): ResponseInterface
+    {
+        $this->getSession($request)->write($this->config['sessionKey'], $data);
+
+        return $response;
+    }
+
+    protected function getSession(ServerRequestInterface $request): Session
+    {
+        return $request->getAttribute($this->config['sessionAttribute']);
+    }
+}

--- a/src/Authenticator/Storage/StorageInterface.php
+++ b/src/Authenticator/Storage/StorageInterface.php
@@ -12,39 +12,40 @@
  * @since         1.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-namespace Authentication\Authenticator;
+namespace Authentication\Authenticator\Storage;
 
-use Authentication\Authenticator\Storage\StorageInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
- * Persistence Interface
+ * Storage Interface
  */
-interface PersistenceInterface
+interface StorageInterface
 {
-
     /**
-     * Returns a persistence object
+     * Reads the data from the storage.
      *
-     * @return \Authentication\Authenticator\Storage\StorageInterface;
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request object.
+     * @return null|mixed
      */
-    public function getStorage(): StorageInterface;
+    public function read(ServerRequestInterface $request);
 
     /**
-     * Persists the users data
+     * Persists data in the storage.
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The request object.
      * @param \Psr\Http\Message\ResponseInterface $response The response object.
-     * @param \ArrayAccess|array $identity Identity data to persist.
-     * @return ResponseInterface Returns response object
+     * @param mixed $data Data to persist.
+     * @return ResponseInterface Returns the modified response object
      */
-    public function persistIdentity(ServerRequestInterface $request, ResponseInterface $response, $identity): ResponseInterface;
+    public function write(ServerRequestInterface $request, ResponseInterface $response, $data): ResponseInterface;
 
     /**
-     * Clears the identity data
+     * Clears the data form a storage.
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The request object.
      * @param \Psr\Http\Message\ResponseInterface $response The response object.
-     * @return ResponseInterface Returns response object
+     * @return ResponseInterface Returns the modified response object
      */
-    public function clearIdentity(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface;
+    public function clear(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface;
 }

--- a/src/Middleware/AuthenticationPsr15Middleware.php
+++ b/src/Middleware/AuthenticationPsr15Middleware.php
@@ -118,7 +118,7 @@ class AuthenticationPsr15Middleware implements MiddlewareInterface
         if ($handlerResult instanceof ResponseInterface) {
             foreach ($this->authenticators as $authenticator) {
                 if ($authenticator instanceof PersistenceInterface) {
-                    //$authenticator->persistence()->save($identity);
+                    $handlerResult = $authenticator->persistIdentity($request, $handlerResult, $authResult->getData());
                 }
             }
         }


### PR DESCRIPTION
Cookie/Session persistence is renamed to "Storage".

Storage is responsible for simple read/write logic with request/response involved.
Authenticator persistence methods should handle additional logic for checks and data formatting.

